### PR TITLE
feat: 사용자 전적 개요 페이지 구현

### DIFF
--- a/frontend/assets/css/common/body.css
+++ b/frontend/assets/css/common/body.css
@@ -2,7 +2,16 @@ body {
     background-image: linear-gradient(0deg, #45003B, #191D40);
     width: 100vw;
     height: 100vh;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-use-select: none;
+    user-select: none;;
 }
 
-body.histories {
+img {
+    -webkit-user-drag: none;
+    -khtml-user-drag: none;
+    -moz-user-drag: none;
+    -o-user-drag: none;
+    user-drag: none;
 }

--- a/frontend/assets/css/histories.css
+++ b/frontend/assets/css/histories.css
@@ -223,3 +223,34 @@ footer.histories {
     height: 21.5vh;
     margin-top: 2vh;
 }
+
+/************ Histories Summary ************/
+.histories.summary#summary-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+    color: white;
+    font-family: Galmuri11-Bold, serif;
+    font-size: 2.2rem;
+}
+
+.histories.summary #user-info {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    width: 20%;
+    height: 100%;
+    margin-right: 2vw;
+}
+
+.histories.summary #user-info > img {
+    width: 12vw;
+    margin-bottom: 1vh;
+}
+
+.histories.summary#data > div:not(:last-child) {
+    margin-bottom: 3vh;
+}

--- a/frontend/src/pages/histories/custom-page.js
+++ b/frontend/src/pages/histories/custom-page.js
@@ -10,6 +10,7 @@ export default function CustomHistories(mode) {
   this.$pagination = document.getElementById("pagination");
 
   this.init = () => {
+    this.customList.textContent = "";
     this.$pagination.style.display = "block";
   }
 
@@ -25,11 +26,10 @@ export default function CustomHistories(mode) {
    */
   this.render = () => {
     this.init();
-    this.customList.innerHTML = `
+    this.customList.insertAdjacentHTML("afterbegin", `
         <div class="histories" id="list-wrapper"></div>
-        `
+        `);
     let $listWrapper = document.getElementById("list-wrapper");
-    $listWrapper.innerHTML = '';
     if (mode === "1vs1") {
       this.render1vs1($listWrapper);
     }

--- a/frontend/src/pages/histories/page.js
+++ b/frontend/src/pages/histories/page.js
@@ -25,7 +25,7 @@ export default function Histories($container) {
    */
   this.renderLayout = () => {
     importCss('../../../assets/css/histories.css')
-    this.$container.innerHTML = `
+    this.$container.insertAdjacentHTML("afterbegin", `
         <div class="histories" id="content-wrapper">
             <nav class="histories" id="mode">
                 <div class="histories" id="summary" href="">
@@ -66,7 +66,7 @@ export default function Histories($container) {
                 </div>
             </footer>
         </div>
-        `;
+        `);
   }
 
   this.renderList = () => {

--- a/frontend/src/pages/histories/page.js
+++ b/frontend/src/pages/histories/page.js
@@ -70,7 +70,7 @@ export default function Histories($container) {
   }
 
   this.renderList = () => {
-    return new Summary(document.getElementById("list"));
+    return Summary;
   }
 
   /**

--- a/frontend/src/pages/histories/page.js
+++ b/frontend/src/pages/histories/page.js
@@ -70,7 +70,8 @@ export default function Histories($container) {
   }
 
   this.renderList = () => {
-    return Summary;
+    let $list = document.getElementById("list");
+    Summary.bind($list)();
   }
 
   /**

--- a/frontend/src/pages/histories/summary-page.js
+++ b/frontend/src/pages/histories/summary-page.js
@@ -52,13 +52,6 @@ export default async function Summary() {
    */
   this.getUsersHistoriesSummary = async function () {
     // TODO => API 요청으로 await 해서 데이터 받아오기
-    // const nickname = localStorage.getItem("nickname");
-    // const data = await fetch(`/api/users/${nickname}/info`, {
-    //   method: "GET",
-    //   headers: {
-    //     "Content-Type": "application/json",
-    //   },
-    // }).then((res) => res.json());
     return {
       nickname: 'yena',
       avatar: '../../../assets/images/avatar/green.png',
@@ -74,15 +67,37 @@ export default async function Summary() {
    * @param {{nickname: string, avatar: string}} props 사용자의 닉네임과 아바타 이미지 주소
    */
   this.renderUserInfo = (props) => {
-    return (``);
+    return (`
+        <img class="histories summary" src="${props.avatar}" alt="avatar">
+        <span>${props.nickname}</span>
+    `);
   }
 
   /**
    * 사용자의 전적 개요 데이터를 렌더링합니다.
-   * @param {{custom_win_rate: number, tournament_win_rate: number, rating: number, win_rate: number}} props 사용자의 전적 개요 데이터
+   * @param {{rating: number, win_rate: number, custom_win_rate: number, tournament_win_rate: number}} props 사용자의 전적 개요 데이터
    */
   this.renderHistoriesSummary = (props) => {
-    return (``);
+    return (`
+      <div class="histories summary" id="data">
+        <div class="histories summary" id="rating">
+          <span>Rating: </span>
+          <span>${props.rating}</span>
+        </div>
+        <div class="histories summary" id="win-rate">
+          <span>전체 승률: </span>
+          <span>${props.win_rate}%</span>
+        </div>
+        <div class="histories summary" id="custom-win-rate">
+          <span>사용자 지정 모드 승률: </span>
+          <span>${props.custom_win_rate}%</span>
+        </div>
+        <div class="histories summary" id="tournament-win-rate">
+          <span>토너먼트 모드 승률: </span>
+          <span>${props.tournament_win_rate}%</span>
+        </div>
+      </div>
+    `);
   }
 
   this.init();

--- a/frontend/src/pages/histories/summary-page.js
+++ b/frontend/src/pages/histories/summary-page.js
@@ -6,8 +6,14 @@ export default async function Summary() {
     this.$pagination.style.display = "none";
   }
 
+  this.useState = async () => {
+    this.newState = await this.getUsersHistoriesSummary();
+  }
+
   this.setState = () => {
-    this.render();
+    if (this.state === this.newState) return;
+    this.state = this.newState;
+    this.render(this.state);
   }
 
   /**
@@ -86,6 +92,7 @@ export default async function Summary() {
   }
 
   this.init();
-  const data = await this.getUsersHistoriesSummary();
-  this.render(data);
+  await this.useState();
+  this.setState();
+  this.render(this.state);
 }

--- a/frontend/src/pages/histories/summary-page.js
+++ b/frontend/src/pages/histories/summary-page.js
@@ -1,6 +1,7 @@
 export default async function Summary() {
   this.$container = document.getElementById("list");
   this.$pagination = document.getElementById("pagination");
+  this.needToRender = false;
 
   this.init = () => {
     this.$pagination.style.display = "none";
@@ -10,32 +11,28 @@ export default async function Summary() {
     this.newState = await this.getUsersHistoriesSummary();
   }
 
-  this.setState = () => {
-    if (this.state === this.newState) return;
+  this.setState = async () => {
+    if (this.state === this.newState) {
+      this.needToRender = false;
+      return;
+    }
     this.state = this.newState;
-    this.render(this.state);
+    this.needToRender = true;
   }
 
   /**
    * 사용자의 전적 개요를 렌더링합니다.
-   * @param data {{
-   *    nickname: string,
-   *    avatar: string,
-   *    rating: number,
-   *    win_rate: number,
-   *    custom_win_rate: number,
-   *    tournament_win_rate: number
-   * }} 사용자의 전적 개요 데이터. nickname, avatar, rating, win_rate, custom_win_rate, tournament_win_rate를 포함합니다.
    */
-  this.render = (data) => {
-    const { nickname, avatar, rating, win_rate, custom_win_rate, tournament_win_rate } = data;
+  this.render = () => {
+    if (!this.needToRender) return;
+    const { nickname, avatar, rating, win_rate, custom_win_rate, tournament_win_rate } = this.state;
     this.$container.innerText = `
     <div class="histories summary" id="summary-wrapper">
         <div class="histories summary" id="user-info">
-            ${renderUserInfo(nickname, avatar)}
+            ${this.renderUserInfo({ nickname, avatar })}
         </div>
         <div class="histories summary" id="histories-info">
-            ${renderHistoriesSummary(rating, win_rate, custom_win_rate, tournament_win_rate)}
+            ${this.renderHistoriesSummary({ rating, win_rate, custom_win_rate, tournament_win_rate })}
         </div>
     </div>
     `;
@@ -73,26 +70,22 @@ export default async function Summary() {
 
   /**
    * 사용자의 정보를 렌더링합니다.
-   * @param nickname {string} 사용자의 닉네임
-   * @param avatar {string} 사용자의 아바타 이미지 URL
+   * @param {{nickname: string, avatar: string}} props 사용자의 닉네임과 아바타 이미지 주소
    */
-  this.renderUserInfo = (nickname, avatar) => {
-
+  this.renderUserInfo = (props) => {
+    return ``;
   }
 
   /**
    * 사용자의 전적 개요 데이터를 렌더링합니다.
-   * @param rating {number} 사용자의 레이팅 점수
-   * @param win_rate {number} 사용자의 전체 승률 (토너먼트 + 커스텀)
-   * @param custom_win_rate {number} 사용자의 커스텀 게임 승률 (1 vs 1 모드 + 토너먼트 모드)
-   * @param tournament_win_rate {number} 사용자의 토너먼트 게임 승률
+   * @param {{custom_win_rate: number, tournament_win_rate: number, rating: number, win_rate: number}} props 사용자의 전적 개요 데이터
    */
-  this.renderHistoriesSummary = (rating, win_rate, custom_win_rate, tournament_win_rate) => {
-
+  this.renderHistoriesSummary = (props) => {
+    return ``;
   }
 
   this.init();
   await this.useState();
-  this.setState();
-  this.render(this.state);
+  await this.setState();
+  this.render();
 }

--- a/frontend/src/pages/histories/summary-page.js
+++ b/frontend/src/pages/histories/summary-page.js
@@ -26,7 +26,7 @@ export default async function Summary() {
   this.render = () => {
     if (!this.needToRender) return;
     const { nickname, avatar, rating, win_rate, custom_win_rate, tournament_win_rate } = this.state;
-    this.$container.innerText = `
+    this.$container.innerHTML = `
     <div class="histories summary" id="summary-wrapper">
         <div class="histories summary" id="user-info">
             ${this.renderUserInfo({ nickname, avatar })}
@@ -73,7 +73,7 @@ export default async function Summary() {
    * @param {{nickname: string, avatar: string}} props 사용자의 닉네임과 아바타 이미지 주소
    */
   this.renderUserInfo = (props) => {
-    return ``;
+    return (``);
   }
 
   /**
@@ -81,7 +81,7 @@ export default async function Summary() {
    * @param {{custom_win_rate: number, tournament_win_rate: number, rating: number, win_rate: number}} props 사용자의 전적 개요 데이터
    */
   this.renderHistoriesSummary = (props) => {
-    return ``;
+    return (``);
   }
 
   this.init();

--- a/frontend/src/pages/histories/summary-page.js
+++ b/frontend/src/pages/histories/summary-page.js
@@ -1,4 +1,4 @@
-export default function Summary() {
+export default async function Summary() {
   this.$container = document.getElementById("list");
   this.$pagination = document.getElementById("pagination");
 
@@ -10,10 +10,82 @@ export default function Summary() {
     this.render();
   }
 
-  this.render = () => {
-    this.init();
-    this.$container.innerText = "개요";
+  /**
+   * 사용자의 전적 개요를 렌더링합니다.
+   * @param data {{
+   *    nickname: string,
+   *    avatar: string,
+   *    rating: number,
+   *    win_rate: number,
+   *    custom_win_rate: number,
+   *    tournament_win_rate: number
+   * }} 사용자의 전적 개요 데이터. nickname, avatar, rating, win_rate, custom_win_rate, tournament_win_rate를 포함합니다.
+   */
+  this.render = (data) => {
+    const { nickname, avatar, rating, win_rate, custom_win_rate, tournament_win_rate } = data;
+    this.$container.innerText = `
+    <div class="histories summary" id="summary-wrapper">
+        <div class="histories summary" id="user-info">
+            ${renderUserInfo(nickname, avatar)}
+        </div>
+        <div class="histories summary" id="histories-info">
+            ${renderHistoriesSummary(rating, win_rate, custom_win_rate, tournament_win_rate)}
+        </div>
+    </div>
+    `;
   }
 
-  this.render();
+  /**
+   * 사용자의 전적 개요 데이터를 가져옵니다.
+   * @returns {Promise<{
+   *    nickname: string,
+   *    avatar: string,
+   *    rating: number,
+   *    win_rate: number,
+   *    custom_win_rate: number,
+   *    tournament_win_rate: number
+   * }>}
+   */
+  this.getUsersHistoriesSummary = async function () {
+    // TODO => API 요청으로 await 해서 데이터 받아오기
+    // const nickname = localStorage.getItem("nickname");
+    // const data = await fetch(`/api/users/${nickname}/info`, {
+    //   method: "GET",
+    //   headers: {
+    //     "Content-Type": "application/json",
+    //   },
+    // }).then((res) => res.json());
+    return {
+      nickname: 'yena',
+      avatar: '../../../assets/images/avatar/green.png',
+      rating: 2103,
+      win_rate: 43,
+      custom_win_rate: 52,
+      tournament_win_rate: 45,
+    };
+  }
+
+  /**
+   * 사용자의 정보를 렌더링합니다.
+   * @param nickname {string} 사용자의 닉네임
+   * @param avatar {string} 사용자의 아바타 이미지 URL
+   */
+  this.renderUserInfo = (nickname, avatar) => {
+
+  }
+
+  /**
+   * 사용자의 전적 개요 데이터를 렌더링합니다.
+   * @param rating {number} 사용자의 레이팅 점수
+   * @param win_rate {number} 사용자의 전체 승률 (토너먼트 + 커스텀)
+   * @param custom_win_rate {number} 사용자의 커스텀 게임 승률 (1 vs 1 모드 + 토너먼트 모드)
+   * @param tournament_win_rate {number} 사용자의 토너먼트 게임 승률
+   */
+  this.renderHistoriesSummary = (rating, win_rate, custom_win_rate, tournament_win_rate) => {
+
+  }
+
+  this.init();
+  const data = await this.getUsersHistoriesSummary();
+  this.render(data);
 }

--- a/frontend/src/pages/histories/summary-page.js
+++ b/frontend/src/pages/histories/summary-page.js
@@ -4,6 +4,7 @@ export default async function Summary() {
   this.needToRender = false;
 
   this.init = () => {
+    this.$container.textContent = "";
     this.$pagination.style.display = "none";
   }
 
@@ -26,7 +27,7 @@ export default async function Summary() {
   this.render = () => {
     if (!this.needToRender) return;
     const { nickname, avatar, rating, win_rate, custom_win_rate, tournament_win_rate } = this.state;
-    this.$container.innerHTML = `
+    this.$container.insertAdjacentHTML("afterbegin", `
     <div class="histories summary" id="summary-wrapper">
         <div class="histories summary" id="user-info">
             ${this.renderUserInfo({ nickname, avatar })}
@@ -35,7 +36,7 @@ export default async function Summary() {
             ${this.renderHistoriesSummary({ rating, win_rate, custom_win_rate, tournament_win_rate })}
         </div>
     </div>
-    `;
+    `);
   }
 
   /**


### PR DESCRIPTION
**************************************************************************************
# 사용자 전적 개요 페이지
- [사용자 전적 개요 - API 명세서](https://github.com/orgs/GunGonGamLee/projects/2/views/1?pane=issue&itemId=50352953)를 따름
- 사용자 정보를 렌더링하는 `renderUserInfo()`와 전적 개요를 렌더링하는 `renderHistoriesSummary()` 함수로 분리
- 사용자 데이터를 가져오는 함수인 `async useState()` 구현
- 이전 데이터와 비교했을 때, 달라진 점이 있다면 `setState()`에서 `this.state`를 최신 사용자 데이터로 변경
- `setState()`로 데이터가 변경되었다면 그때 `render()` 함수 호출하여 사용자 정보 및 전적 개요 재렌더링
- innerText, innerHTML 대신 textContent, insertAdjacentHTML 사용

# 스크린샷
https://github.com/GunGonGamLee/ft_transcendence/assets/50291995/5dc00a1f-dc09-4300-8166-a6ea343c9c97

# 비고
## 참고자료
[innerHTML 사용하지마!](https://kit-developer.tistory.com/27#--%--Element-insertAdjacentHTML--)
**************************************************************************************
