### PR TITLE
feat: useState 훅 구현

### DIFF
--- a/frontend/src/pages/game-mode/page.js
+++ b/frontend/src/pages/game-mode/page.js
@@ -1,12 +1,13 @@
-import { navigate } from "../../utils/navigate.js";
 import { importCss } from "../../utils/importCss.js";
 import gameModeUnit from "./gameModeUnit.js";
+import useState from "../../utils/useState.js";
 /**
  * @param {HTMLElement} $container
  */
+
 export default function GameMode($container) {
   this.$container = $container;
-
+  let [getGameMode, setGameMode] = useState(0, this);
   this.setState = () => {
     this.render();
   };
@@ -15,17 +16,18 @@ export default function GameMode($container) {
     importCss("../../../assets/css/game-mode.css");
     this.$container.innerHTML = `
         <div class="game-mode-container">
-        ${gameModeUnit(0)}
-        ${gameModeUnit(1)}
-        ${gameModeUnit(2)}
-    </div>
+          ${gameModeUnit(getGameMode())}
+          ${gameModeUnit(getGameMode())}
+          ${gameModeUnit(getGameMode())}
+          <button id="button2" style="position: absolute; bottom: 10px; right: 10px;">state</button>
+        </div>
 	  `;
   };
 
   this.render();
   $container.addEventListener("click", (e) => {
     if (e.target.id === "button2") {
-      navigate("/");
+      setGameMode(getGameMode() + 1);
     }
   });
 }

--- a/frontend/src/utils/useState.js
+++ b/frontend/src/utils/useState.js
@@ -1,0 +1,17 @@
+/**
+ * @description useState 훅 구현
+ * @param state 상태
+ * @param component 전달된 컴포넌트
+ * @returns [getState, setState] 반환
+ * @example 앞으로 모든 컴포넌트 렌더링 함수 다 render로 통일 해야 합니다. 안그러면 최신화가 안됩니다.
+ */
+export default function useState(state, component) {
+  const getState = () => {
+    return state;
+  };
+  const setState = (newState) => {
+    state = newState;
+    component.render(); // 그냥 render를 인자로 받으면 최신화가 안되버리는..!
+  };
+  return [getState, setState];
+}


### PR DESCRIPTION
**************************************************************************************
# 내용 입력
도저히 안되겠어서 react의 가장 유명한 훅인 useState 간이로 구현했습니다.

좀 귀찮은 사항이 있긴 합니다.
1. 앞으로 모든 컴포넌트 렌더링 하는 함수 render()로 통일해야 합니다.  <- setState 안에서 component.render()호출하기 때문
2. 실제 useState와 달리 2번째 인자로 해당 컴포넌트를 전달해야 합니다. 
3. 첫번째로 state 변수가 아닌 getState함수를 리턴합니다 <- 비 참조 타입으로 state 리턴해버리면 최신화가 안됩니다 ㅠ

더 좋은 방식 의견 환영합니다! 만들고 나니 안이쁘긴 하네요..
game-mode 페이지에 버튼 추가해서 state 변경 시 렌더링 확인하실 수 있게 했습니다. 나중에 삭제할게요~
**************************************************************************************
