### PR TITLE
feat: useState 다른 render 함수명도 허용 가능하게 변경

### DIFF
--- a/frontend/src/pages/game-mode/page.js
+++ b/frontend/src/pages/game-mode/page.js
@@ -7,7 +7,7 @@ import useState from "../../utils/useState.js";
 
 export default function GameMode($container) {
   this.$container = $container;
-  let [getGameMode, setGameMode] = useState(0, this);
+  let [getGameMode, setGameMode] = useState(0, this, "render");
   this.setState = () => {
     this.render();
   };

--- a/frontend/src/utils/useState.js
+++ b/frontend/src/utils/useState.js
@@ -2,16 +2,16 @@
  * @description useState 훅 구현
  * @param state 상태
  * @param component 전달된 컴포넌트
+ * @param {string}render 렌더링 함수 명
  * @returns [getState, setState] 반환
- * @example 앞으로 모든 컴포넌트 렌더링 함수 다 render로 통일 해야 합니다. 안그러면 최신화가 안됩니다.
  */
-export default function useState(state, component) {
+export default function useState(state, component, render) {
   const getState = () => {
     return state;
   };
   const setState = (newState) => {
     state = newState;
-    component.render(); // 그냥 render를 인자로 받으면 최신화가 안되버리는..!
+    component[render](); // 그냥 render를 인자로 받으면 최신화가 안되버리는..!
   };
   return [getState, setState];
 }

--- a/frontend/src/utils/useState.js
+++ b/frontend/src/utils/useState.js
@@ -1,7 +1,7 @@
 /**
  * @description useState 훅 구현
  * @param state 상태
- * @param component 전달된 컴포넌트
+ * @param {object}component 전달된 컴포넌트
  * @param {string}render 렌더링 함수 명
  * @returns [getState, setState] 반환
  */


### PR DESCRIPTION
**************************************************************************************
# 내용 입력
함수명이 render만 호환되는게 불편해져서 3 번째 인자로 함수명을 string으로 받아서 사용 가능하게 변경했습니다.
사용 하려면 
let [state, setState] = useState(0, this, "render"); 
요렇게 써야 합니다 ㅋㅋ...
여기서 this는 최상단 렌더링 객체이니 htmlElement를 넣으시면 안됩니다!!!
**************************************************************************************
