### PR TITLE
chore: useState 오버로딩

### DIFF
--- a/frontend/src/utils/useState.js
+++ b/frontend/src/utils/useState.js
@@ -1,6 +1,6 @@
 /**
  * @description useState 훅 구현
- * @param {array | number | string | boolean}stateInput 상태
+ * @param {array | number | string | boolean | Object}stateInput 상태
  * @param {object}component 전달된 컴포넌트
  * @param {string}render 렌더링 함수 명
  * @returns [getState, setState] 반환

--- a/frontend/src/utils/useState.js
+++ b/frontend/src/utils/useState.js
@@ -1,13 +1,13 @@
 /**
  * @description useState 훅 구현
- * @param {array | number | string | boolean | Object}stateInput 상태
+ * @param {array | number | string | boolean}stateInput 상태
  * @param {object}component 전달된 컴포넌트
  * @param {string}render 렌더링 함수 명
  * @returns [getState, setState] 반환
  * @description 배열이 인자로 올 때 동작이 다르니 유의해서 사용하세요
  */
 export default function useState(stateInput, component, render) {
-  if (typeof stateInput === "object") {
+  if (typeof stateInput === "object") { // js에선 배열도 object로 인식함
     let state = [...stateInput];
     const getState = () => {
       return state;

--- a/frontend/src/utils/useState.js
+++ b/frontend/src/utils/useState.js
@@ -1,17 +1,32 @@
 /**
  * @description useState 훅 구현
- * @param state 상태
+ * @param {array | number | string}stateInput 상태
  * @param {object}component 전달된 컴포넌트
  * @param {string}render 렌더링 함수 명
  * @returns [getState, setState] 반환
+ * @description 배열이 인자로 올 때 동작이 다르니 유의해서 사용하세요
  */
-export default function useState(state, component, render) {
-  const getState = () => {
-    return state;
-  };
-  const setState = (newState) => {
-    state = newState;
-    component[render](); // 그냥 render를 인자로 받으면 최신화가 안되버리는..!
-  };
-  return [getState, setState];
+export default function useState(stateInput, component, render) {
+  if (typeof stateInput === "object") {
+    let state = [...stateInput];
+    const getState = () => {
+      return state;
+    };
+    const setState = (newState) => {
+      state = [...newState];
+      component[render](); // 그냥 render를 인자로 받으면 최신화가 안되버리는..!
+    };
+    return [getState, setState];
+  } else if (typeof stateInput === "number" || typeof stateInput === "string") {
+      let state = stateInput;
+      const getState = () => {
+        return state;
+      };
+      const setState = (newState) => {
+        state = newState;
+        component[render](); // 그냥 render를 인자로 받으면 최신화가 안되버리는..!
+      };
+      return [getState, setState];
+  }
 }
+

--- a/frontend/src/utils/useState.js
+++ b/frontend/src/utils/useState.js
@@ -1,6 +1,6 @@
 /**
  * @description useState 훅 구현
- * @param {array | number | string}stateInput 상태
+ * @param {array | number | string | boolean | Object}stateInput 상태
  * @param {object}component 전달된 컴포넌트
  * @param {string}render 렌더링 함수 명
  * @returns [getState, setState] 반환
@@ -17,7 +17,7 @@ export default function useState(stateInput, component, render) {
       component[render](); // 그냥 render를 인자로 받으면 최신화가 안되버리는..!
     };
     return [getState, setState];
-  } else if (typeof stateInput === "number" || typeof stateInput === "string") {
+  } else {
       let state = stateInput;
       const getState = () => {
         return state;


### PR DESCRIPTION
**************************************************************************************
# 내용 입력
state 한번에 여러개 바꿔야 할 일이 생겨서 인자로 배열도 받을 수 있게 했습니다.
js는 오버로딩을 지원 안하네요 ㅋㅋ 유사언어 수준
type체크하고 분기 줘서 오버로딩 했습니다

예를들어 register 페이지에서 렌더링 한번에 변경될 state가 5개정도 있는데,
배열을 인자로 받지 않고 하나하나 useState를 하게 되면 5번 렌더링이 일어납니다.
이 같은 상황을 피하기 위해 react처럼 가상 돔 구현은 도저히 못하겠고 이렇게 하겠습니다.

아래처럼 object나 array도 지원합니다.
``` js
let object = {command: '인증번호를 적어라', placeholder: '인증번호는 6글자다.', maxLength: 6, isValidAuthBtn: true};
    let [getState, setState] = useState(object, this, 'render');
```
**************************************************************************************
