### PR TITLE
build: dev 모드와 prod 모드 분리

### DIFF
--- a/backend/login/views.py
+++ b/backend/login/views.py
@@ -39,7 +39,10 @@ INTRA42_USERINFO_API = settings.INTRA42_USERINFO_API
 
 SECRET_KEY = settings.SECRET_KEY
 DEFAULT_FROM_MAIL = settings.DEFAULT_FROM_MAIL
-EMAIL_AUTH_URI = 'https://localhost:443/auth'
+if settings.DEBUG:
+    EMAIL_AUTH_URI = 'http://localhost:3000/auth'
+else:
+    EMAIL_AUTH_URI = 'https://localhost:443/auth'
 
 
 class OAuthLoginView(APIView):
@@ -237,7 +240,10 @@ class VerificationCodeAgainView(APIView):
 class AuthUtils:
     @staticmethod
     def validate_jwt_token_and_get_user(request):
-        jwt_token = request.COOKIES.get('jwt')
+        if settings.DEBUG:
+            jwt_token = request.headers.get('Authorization').split(' ')[1]
+        else:
+            jwt_token = request.COOKIES.get('jwt')
         decoded_token = jwt.decode(jwt_token, SECRET_KEY, algorithms=['HS256'])
         user_email = decoded_token.get('user_email')
         user = User.objects.get(email=user_email)

--- a/backend/src/settings.py
+++ b/backend/src/settings.py
@@ -121,11 +121,13 @@ else:
 
 # SECURITY WARNING: don't run with debug turned on in production!
 
-ALLOWED_HOSTS = ['*']
-
+ALLOWED_HOSTS = ['localhost']
+CORS_ALLOW_ALL_ORIGINS = False
+CORS_ALLOWED_ORIGINS = [
+    "http://localhost:3000",
+    "http://localhost:8000",
+]
 # Application definition
-
-CORS_ALLOW_ALL_ORIGINS = True
 
 INSTALLED_APPS = [
     "daphne",
@@ -157,6 +159,7 @@ AUTH_USER_MODEL = 'users.User'
 REST_USE_JWT = True
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -165,7 +168,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'corsheaders.middleware.CorsMiddleware',
 ]
 
 ROOT_URLCONF = 'src.urls'

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,7 +13,8 @@
 <body>
 <header id="header"></header>
 <div id="app" style="width: 100vw; height: 88vh;"></div>
-      <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-      <script type="module" src="main.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script>window.mode = "dev"</script>
+    <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/frontend/src/constants/routeInfo.js
+++ b/frontend/src/constants/routeInfo.js
@@ -1,22 +1,22 @@
-import GameMode from '../pages/game-mode/page.js';
-import auth from '../pages/auth/page.js';
-import Register from '../pages/register/page.js';
+import GameMode from "../pages/game-mode/page.js";
+import Register from "../pages/register/page.js";
 import Histories from "../pages/histories/page.js";
-import RegisterHeader from '../header/registerHeader/header.js';
-import MainHeader from '../header/mainHeader/header.js';
+import RegisterHeader from "../header/registerHeader/header.js";
+import MainHeader from "../header/mainHeader/header.js";
 import WaitingRoom from "../pages/waiting-room/page.js";
-import Login from '../pages/login/page.js'
-import CustomGameList from '../pages/custom-game-list/page.js';
+import Login from "../pages/login/page.js";
+import CustomGameList from "../pages/custom-game-list/page.js";
+import Auth from "../pages/auth/page.js";
 
 /**
  * 원하는 경로에 따라 렌더링할 컴포넌트를 정의합니다.
  */
 export const routes = [
   { path: /^\/$/, page: Login, header: RegisterHeader },
-  { path: /^\/auth(?:\?.*)?$/, page: auth, header: RegisterHeader },
+  { path: /^\/auth(?:\?.*)?$/, page: Auth, header: RegisterHeader },
   { path: /^\/register$/, page: Register, header: RegisterHeader },
   { path: /^\/game-mode$/, page: GameMode, header: MainHeader },
-  { path: /^\/histories$/, page: Histories, header: MainHeader},
+  { path: /^\/histories$/, page: Histories, header: MainHeader },
   { path: /^\/waiting-room$/, page: WaitingRoom, header: MainHeader },
-  { path: /^\/custom-game-list$/, page: CustomGameList, header: MainHeader}
-]
+  { path: /^\/custom-game-list$/, page: CustomGameList, header: MainHeader },
+];

--- a/frontend/src/global.js
+++ b/frontend/src/global.js
@@ -1,0 +1,12 @@
+const devBackend = "http://localhost:8000/api";
+const prodBackend = "https://localhost/api";
+
+const getAPIUrl = async () => {
+  if (window.mode === "dev") {
+    return devBackend;
+  } else {
+    return prodBackend;
+  }
+};
+
+export const BACKEND = await getAPIUrl();

--- a/frontend/src/global.js
+++ b/frontend/src/global.js
@@ -1,7 +1,7 @@
 const devBackend = "http://localhost:8000/api";
 const prodBackend = "https://localhost/api";
 
-const getAPIUrl = async () => {
+const getAPIUrl = () => {
   if (window.mode === "dev") {
     return devBackend;
   } else {
@@ -9,4 +9,4 @@ const getAPIUrl = async () => {
   }
 };
 
-export const BACKEND = await getAPIUrl();
+export const BACKEND = getAPIUrl();

--- a/frontend/src/header/mainHeader/header.js
+++ b/frontend/src/header/mainHeader/header.js
@@ -1,9 +1,8 @@
-import { hoverChangeCursor } from "../../utils/hoverEvent.js";
 import { importCss } from "../../utils/importCss.js";
-import { getCookie } from "../../utils/cookie.js";
 import { navigate } from "../../utils/navigate.js";
 import { click } from "../../utils/clickEvent.js";
-import Histories from "../../pages/histories/page.js";
+import { BACKEND } from "../../global.js";
+import { getCookie } from "../../utils/cookie.js";
 
 /**
  * 사용자 전적 페이지에 사용하는 header 컴포넌트
@@ -16,14 +15,20 @@ export default function historiesHeader($container) {
   this.imagePath = "../../../assets/images";
 
   this.setState = () => {
-    const token = getCookie("jwt");
-    fetch("https://localhost/api/usrs/me").then((response) => {
+    fetch(`${BACKEND}/users/me`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${getCookie("jwt")}`,
+      },
+    }).then((response) => {
       if (response.status === 200) {
         response.json().then((data) => {
           this.render(data.nickname, data.avatar_file_name);
         });
       } else {
         // TODO => 에러 페이지로 이동
+        navigate("/");
       }
     });
   };

--- a/frontend/src/header/registerHeader/header.js
+++ b/frontend/src/header/registerHeader/header.js
@@ -7,13 +7,13 @@ export default function registerHeader($container) {
 
   this.setState = () => {
     this.render();
-  }
+  };
 
   this.render = () => {
     this.$container.innerHTML = `
-        <div class="register-header-wrapper">
-        `
-  }
+        <div class="register-header-wrapper"></div>
+        `;
+  };
 
   this.render();
 }

--- a/frontend/src/pages/login/page.js
+++ b/frontend/src/pages/login/page.js
@@ -1,6 +1,7 @@
 import { click } from "../../utils/clickEvent.js";
 import { navigate } from "../../utils/navigate.js";
 import { getCookie } from "../../utils/cookie.js";
+import { BACKEND } from "../../global.js";
 /**
  * header 컴포넌트
  * @param {HTMLElement} $container
@@ -79,10 +80,10 @@ export default function Login($container) {
     const fortyTwo = document.getElementById("forty-two");
 
     click(google, () => {
-      window.location.href = "http://localhost:8000/api/login/google/";
+      window.location.href = `${BACKEND}/login/google/`;
     });
     click(fortyTwo, () => {
-      window.location.href = "http://localhost:8000/api/login/intra42/";
+      window.location.href = `${BACKEND}/login/intra42/`;
     });
   };
 
@@ -97,7 +98,7 @@ export default function Login($container) {
         ...(token ? { Authorization: "Bearer " + token } : {}),
       },
     };
-    fetch("https://localhost/api/users/me/", requestOption)
+    fetch(`${BACKEND}/users/me/`, requestOption)
       .then((response) => {
         if (response.status === 200) {
           navigate("/game-mode");

--- a/frontend/src/pages/register/page.js
+++ b/frontend/src/pages/register/page.js
@@ -1,6 +1,8 @@
 import { importCss } from "../../utils/importCss.js";
 import { navigate } from "../../utils/navigate.js";
 import useState from "../../utils/useState.js";
+import { BACKEND } from "../../global.js";
+import { getCookie } from "../../utils/cookie.js";
 /**
  * @param {HTMLElement} $container
  */
@@ -56,6 +58,7 @@ export default function Register($container) {
   this.getRequestOptions = (jwt, key) => {
     return {
       method: "POST",
+      mode: "cors",
       headers: {
         "Content-Type": "application/json",
         // JWT 토큰이 존재하는 경우, Authorization 헤더에 추가합니다
@@ -69,9 +72,9 @@ export default function Register($container) {
   };
 
   this.fetchAuthCode = () => {
-    const jwtToken = localStorage.getItem("jwtToken");
+    const jwtToken = getCookie("jwt");
     fetch(
-      "https://localhost/api/login/verification-code/",
+      `${BACKEND}/login/verification-code/`,
       this.getRequestOptions(jwtToken, "code"),
     )
       .then((response) => {
@@ -121,7 +124,7 @@ export default function Register($container) {
   this.fetchNickname = () => {
     const jwtToken = localStorage.getItem("jwtToken");
     fetch(
-      "https://localhost/api/users/nickname/",
+      `${BACKEND}/users/nickname/`,
       this.getRequestOptions(jwtToken, "nickname"),
     )
       .then((response) => {
@@ -202,10 +205,7 @@ export default function Register($container) {
 
       // fetch 함수를 사용하여 서버에 요청을 보냅니다
       const jwtToken = localStorage.getItem("jwtToken");
-      fetch(
-        "https://localhost/api/login/email/",
-        this.getRequestOptions(jwtToken, "code"),
-      )
+      fetch(`${BACKEND}/login/email/`, this.getRequestOptions(jwtToken, "code"))
         .then((response) => response.json()) // 응답을 JSON으로 파싱
         .then((data) => {
           // 서버로부터 받은 JWT 토큰을 로컬 스토리지에 저장

--- a/frontend/src/utils/cookie.js
+++ b/frontend/src/utils/cookie.js
@@ -5,11 +5,12 @@
  */
 export function getCookie(name) {
   const cookies = document.cookie.split(";");
-  cookies.filter((cookie) => {
+  const jwtCookie = cookies.find((cookie) => {
     const [key, value] = cookie.split("=");
-    if (key.trim() === name) {
-      return value;
-    }
+    return key.trim() === name;
   });
+  if (jwtCookie) {
+    return jwtCookie.split("=")[1];
+  }
   return null;
 }


### PR DESCRIPTION
**************************************************************************************
# 변경 사항
## 프론트엔드
### 1. `dev | prod` 모드
- 현재 실행 중인 모드가 `dev`인지, `prod`인지 구별하는 `<script>`가 `index.html`에 추가되었습니다.
- 단순 개발 환경이라면 `dev`를, 도커에서 실행하는 환경이라면 `prod`로 바꿔주세요.
  - ex) `index.html`에서 `<script>window.mode = "dev"</script>`의 `"dev"`를 변경

### 2. `BACKEND` 상수 추가
-  앞으로 `fetch`를 사용하여 백엔드 API를 호출할 때 url 부분에 `BACKEND` 상수를 사용해주세요.
  - localhost/api 부분까지 전부 `BACKEND`에 정의되어 있습니다.
  - ex) ```fetch(`${BACKEND}/users/me`, {``` 

### 3. 백엔드 API에 요청 시 JWT 토큰 포함 여부
- `fetch`를 이용하여 백엔드 API에 요청을 보낼 때 반드시 JWT 토큰이 포함되어야 합니다.   
   이는 백엔드에서 개발 모드일 때와 프로덕션 모드일 때 일관성있게 동작하기 위함입니다.

## 백엔드
### 1. `settings.DEBUG`에 따른 분기
- 단순 개발 환경이라면 `settings.DEBUG = True`로, 도커에서 실행하는 환경이라면 `settings.DEBUG = False`로 바꿔주세요.
- `EMAIL_AUTH_URI`의 값이 디버그모드인지, 아닌지에 따라 다릅니다.
- `AuthUtils.validate_jwt_token_and_get_user`에서 JWT 값을 가져올 때 디버그 모드일 경우에는 헤더에서, 디버그 모드가 아닐 경우에는 쿠키에서 가져오도록 했습니다.

### 2. CORS 설정 수정
- `ALLOWED_HOSTS`의 값을 와일드카드에서 특정 호스트로 변경했습니다.
- `CORS_ALLOW_ALL_ORIGINS = False`로 설정하여 일부 ORIGIN을 제외하고는 백엔드와 통신할 수 없습니다.
- `CORS_ALLOWED_ORIGINS`에 백엔드와 통신 가능한 ORIGIN을 추가했습니다.

# 비고
원래는 프론트엔드의 dotenv 라이브러리를 이용하면  
직접적으로 백엔드 API를 호출하며 정상적으로 응답이 오는 URL을 찾는 방식을 사용하지 않아도 되지만,  
바닐라 스크립트 제약으로 불가피하게 이런 식으로 구현했습니다.
**************************************************************************************
