### PR TITLE
feat: 토너먼트 랭크게임 큐 소켓 만들기

### DIFF
--- a/backend/friends/consumers.py
+++ b/backend/friends/consumers.py
@@ -67,7 +67,7 @@ class FriendStatusConsumer(AsyncWebsocketConsumer):
             
     async def friend_status_message(self, event):
         if event['message']['status'] == 'offline':
-            await self.close()
+            await self.disconnect()
 
     @database_sync_to_async
     def get_user_friends(self):

--- a/backend/games/consumers.py
+++ b/backend/games/consumers.py
@@ -8,6 +8,8 @@ from django.core.exceptions import ValidationError
 from channels.db import database_sync_to_async
 from asgiref.sync import sync_to_async
 import logging
+from django.contrib.auth.models import AnonymousUser
+from users.models import User
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +42,6 @@ class GameConsumer(AsyncWebsocketConsumer):
 
     async def is_invalid_user(self):
         user = self.scope['user']
-        from django.contrib.auth.models import AnonymousUser
         logger.info(f"[게임방 입장] user : {user}")
         return isinstance(user, AnonymousUser)
 
@@ -153,3 +154,66 @@ class GameConsumer(AsyncWebsocketConsumer):
         data = event["data"]
 
         await self.send(text_data=json.dumps({"data": data}))
+
+class RankGameConsumer(AsyncWebsocketConsumer):
+    game_queue = []
+    async def connect(self):
+        user = self.scope['user']
+        if isinstance(user, AnonymousUser):
+            await self.close(code=4001)
+            return
+        await self.accept()
+        self.game_queue.append(user.id)
+        logging.info(f'User {user.nickname} 연결되었어요')
+        
+        if len(self.game_queue) >= 4:
+            try:
+                await self.create_game()
+                self.game_queue.clear()
+                logging.info('게임이 생성되고 대기열이 모두 초기화되었어요.')
+            except Exception as e:
+                logging.error(e)
+
+    async def disconnect(self, close_code):
+        user = self.scope['user']
+        if user.id in self.game_queue:
+            self.game_queue.remove(user.id)
+            logging.info(f'User {user.nickname} 이 연결을 끊었어요.')
+            
+    async def create_game(self):
+        users = await sync_to_async(self.get_users)(self.game_queue[:4])
+        game = await sync_to_async(self.create_game_instance)(users)
+        for user_id in self.game_queue[:4]:
+            channel = f'user_{user_id}'
+            await self.channel_layer.send(
+                channel,
+                {
+                    'type': 'game_message',
+                    'message': json.dumps({"game_id": game.id})
+                }
+            )
+
+    @staticmethod
+    def get_users(user_ids):
+        return [User.objects.get(id=user_id) for user_id in user_ids]
+            
+    @staticmethod
+    def create_game_instance(users):
+        try:
+            game = Game.objects.create(
+                mode = 2,
+                status = 2,
+                manager = users[0],
+                player1 = users[1],
+                player2 = users[2],
+                player3 = users[3],
+            )
+            return game
+        except Exception as e:
+            raise e
+    
+    async def game_message(self, event):
+        message = event['message']
+        await self.send(text_data=json.dumps({
+            'message': message
+        }))

--- a/backend/games/consumers.py
+++ b/backend/games/consumers.py
@@ -189,7 +189,7 @@ class RankGameConsumer(AsyncWebsocketConsumer):
                 channel,
                 {
                     'type': 'game_message',
-                    'message': json.dumps({"game_id": game.id})
+                    'message': {"game_id": game.id}
                 }
             )
 
@@ -213,7 +213,6 @@ class RankGameConsumer(AsyncWebsocketConsumer):
             raise e
     
     async def game_message(self, event):
-        message = event['message']
         await self.send(text_data=json.dumps({
-            'message': message
+            'message': event['message']
         }))

--- a/backend/games/routing.py
+++ b/backend/games/routing.py
@@ -1,7 +1,8 @@
-from django.urls import re_path
+from django.urls import re_path, path
 
 from . import consumers
 
 websocket_urlpatterns = [
-    re_path(r"ws/games/(?P<game_id>\w+)/", consumers.GameConsumer.as_asgi())
+    re_path(r"ws/games/(?P<game_id>\w+)/", consumers.GameConsumer.as_asgi()),
+    path('ws/rankgames/', consumers.RankGameConsumer.as_asgi()),
 ]

--- a/backend/src/settings.py
+++ b/backend/src/settings.py
@@ -9,7 +9,7 @@ import time
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ENV_PATH = os.path.join(BASE_DIR, '..', '.env')
 env = environ.Env()
-DEBUG = True
+DEBUG = False
 env.read_env(env_file=ENV_PATH)
 
 def wait_for_vault_client(client, retries=5, delay=5):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - "./volumes/vault/file:/vault/file"
       - "./volumes/vault/logs:/vault/logs"
       - "./volumes/vault/config:/vault/config"
+      - cert-volume:/vault/certs
 
     environment:
       VAULT_ADDR: "http://hashicorp_vault:8200"
@@ -31,6 +32,7 @@ services:
       - app_network
     volumes:
       - static-volume:/backend/static
+      - cert-volume:/backend/certs
     env_file:
       - ./.env
     environment:
@@ -70,6 +72,7 @@ services:
     volumes:
       - "./frontend:/usr/share/nginx/html"
       - static-volume:/usr/share/nginx/html/static
+      - cert-volume:/etc/nginx/certs
       # - "/Users/sejokim/desktop/volumes/nginx/logs:/var/log/nginx"
     logging:
       options:
@@ -138,6 +141,7 @@ services:
 
 volumes:
   static-volume:
+  cert-volume:
 
 networks:
   app_network:


### PR DESCRIPTION
**************************************************************************************

## 📌 랭크 게임 큐 기능 작성완료
- 랭크 게임 큐를 잡는 순간 웹소켓에 연결 시작
- 백엔드 자체의 메모리에 있는 자료구조 큐에 유저가 쌓이기 시작함
- 4명이 꽉 차면 DB에 유저 4명을 저장하고, game 테이블에 내용을 작성한다.
- 백엔드에서 갖고 있던 자료구조 큐를 모두 비운다
- 프론트에 메세지를 보낸다
{
    game_id: game.id
}



**************************************************************************************
