### PR TITLE
fix: consumer disconnect되어있던 거 connect로 수정 / 친구 목록 배열에 avatar까지 담아서 보내기

### DIFF
--- a/backend/friends/consumers.py
+++ b/backend/friends/consumers.py
@@ -67,7 +67,7 @@ class FriendStatusConsumer(AsyncWebsocketConsumer):
             
     async def friend_status_message(self, event):
         if event['message']['status'] == 'offline':
-            await self.disconnect()
+            await self.close()
 
     @database_sync_to_async
     def get_user_friends(self):

--- a/backend/friends/views.py
+++ b/backend/friends/views.py
@@ -30,9 +30,9 @@ class FriendsView(APIView):
                 friend_data = {
                     'nickname' : friend.nickname,
                     'is_online' : friend.is_online,
+                    'avatar' : friend.avatar,
                 }
                 friend_list.append(friend_data)
-
             response_data = {'friends': friend_list}
             return Response(response_data, status=status.HTTP_200_OK)
         except AuthenticationException as e:

--- a/backend/friends/views.py
+++ b/backend/friends/views.py
@@ -30,7 +30,7 @@ class FriendsView(APIView):
                 friend_data = {
                     'nickname' : friend.nickname,
                     'is_online' : friend.is_online,
-                    'avatar' : friend.avatar,
+                    'avatar' : friend.avatar.split('/')[-1],
                 }
                 friend_list.append(friend_data)
             response_data = {'friends': friend_list}


### PR DESCRIPTION
**************************************************************************************

## 📌 변경 및 주의 사항
- 친구 목록 friend_list 배열에 nickname, is_online 외에도 avatar 정보까지 올릴 수 있도록 수정하였습니다.
- 실시간 접속 소켓에 close()를 호출하여 소켓 연결을 끊어야 하는 로직에서 disconnect() 함수를 close() 함수로 수정하여 안정성을 높였습니다.

```
{
  "friends": [
    {
      "nickname": "sejokim",
      "is_online": true,
      "avatar": "https://example.com/path/to/sejokim_avatar.jpg"
    },
    {
      "nickname": "sejojo",
      "is_online": false,
      "avatar": "https://example.com/path/to/sejojo_avatar.jpg"
    },
    {
      "nickname": "sejo",
      "is_online": false,
      "avatar": "https://example.com/path/to/sejo_avatar.jpg"
    }
  ]
}
```
**************************************************************************************
