### PR TITLE
feat: errorpage 헤더 수정 game mode 소켓 연결 후 navigate waiting room에서 tournament로 소켓연결후 보내게 변경

### DIFF
--- a/backend/games/consumers.py
+++ b/backend/games/consumers.py
@@ -287,7 +287,7 @@ class RankGameRoomConsumer(AsyncWebsocketConsumer):
         except Exception as e:
             raise e
 
-    async def game_start(self, event):
+    async def url(self, event):
         await self.send(text_data=json.dumps(event))
 
 

--- a/frontend/src/constants/routeInfo.js
+++ b/frontend/src/constants/routeInfo.js
@@ -1,7 +1,7 @@
 import GameMode from "../pages/game-mode/page.js";
 import Register from "../pages/register/page.js";
 import Histories from "../pages/histories/page.js";
-import RegisterHeader from "../header/registerHeader/header.js";
+import EmptyHeader from "../header/emptyHeader/header.js";
 import MainHeader from "../header/mainHeader/header.js";
 import WaitingRoom from "../pages/waiting-room/page.js";
 import Login from "../pages/login/page.js";
@@ -14,9 +14,9 @@ import Tournament from "../pages/tournament/page.js";
  * 원하는 경로에 따라 렌더링할 컴포넌트를 정의합니다.
  */
 export const routes = [
-  { path: /^\/$/, page: Login, header: RegisterHeader },
-  { path: /^\/auth(?:\?.*)?$/, page: Auth, header: RegisterHeader },
-  { path: /^\/register$/, page: Register, header: RegisterHeader },
+  { path: /^\/$/, page: Login, header: EmptyHeader },
+  { path: /^\/auth(?:\?.*)?$/, page: Auth, header: EmptyHeader },
+  { path: /^\/register$/, page: Register, header: EmptyHeader },
   { path: /^\/game-mode$/, page: GameMode, header: MainHeader },
   { path: /^\/histories$/, page: Histories, header: MainHeader },
   { path: /^\/waiting-room$/, page: WaitingRoom, header: MainHeader },

--- a/frontend/src/header/emptyHeader/header.js
+++ b/frontend/src/header/emptyHeader/header.js
@@ -2,7 +2,7 @@
  * 사용자 전적 페이지에 사용하는 header 컴포넌트
  * @param {HTMLElement} $container
  */
-export default function registerHeader($container) {
+export default function emptyHeader($container) {
   this.$container = $container;
 
   this.setState = () => {

--- a/frontend/src/header/mainHeader/header.js
+++ b/frontend/src/header/mainHeader/header.js
@@ -29,13 +29,13 @@ export default function MainHeader($container) {
         this.ws = new WebSocket(`${WEBSOCKET}/friend_status/`);
         this.ws.onmessage = (msg) => {
           let response = JSON.parse(msg.data);
-
-          if (response.type === 'alreadyLogin') {
-            console.log(response.message);
-            this.ws.close();
-            navigate("error", { errorCode: 4001 });
-            return;
-          }
+          // TODO: 중복로그인 임시로 풀어둠
+          // if (response.type === 'alreadyLogin') {
+          //   console.log(response.message);
+          //   this.ws.close();
+          //   navigate("error", { errorCode: 4001 });
+          //   return;
+          // }
 
           // 업데이트된 내용을 set 함수에 전달합니다.
           setFriendsList(response.data);

--- a/frontend/src/pages/game-mode/page.js
+++ b/frontend/src/pages/game-mode/page.js
@@ -15,14 +15,11 @@ export default function GameMode($container) {
     click($container.querySelector(".unit1"), () => {
       $container.querySelector(".queue-modal").style.display = "flex";
       $container.querySelector(".modal-backdrop").style.display = "block";
-      console.log("clicked");
       this.ws = new WebSocket(`${WEBSOCKET}/rankgames/`);
-      console.log("ws ok");
       this.ws.onmessage = (event) => {
-        console.log(event.data);
         const data = JSON.parse(event.data);
-        console.log(data);
-        console.log("Game started. Game ID: ", data.message.game_id);
+        const newWs = new WebSocket(`${WEBSOCKET}${data.url}`);
+        navigate("/tournament", { socket: newWs });
       };
     });
     click($container.querySelector(".run-btn"), () => {

--- a/frontend/src/pages/tournament/page.js
+++ b/frontend/src/pages/tournament/page.js
@@ -1,8 +1,9 @@
 export default function Tournament($container, info = null) {
-  // const gameModeNum = info.data.mode;
+  if (info === null) {
+    return;
+  }
 
-  // const ws = info.socket;
-  // console.log(info);
+  const ws = info.socket;
 
   const init = () => {
     render();

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -1,6 +1,7 @@
 import { routes } from "./constants/routeInfo.js";
 import ErrorPage from "./pages/errorPage.js";
 import MainHeader from "./header/mainHeader/header.js";
+import emptyHeader from "./header/emptyHeader/header.js";
 /**
  * @param {HTMLElement} $container
  */
@@ -15,18 +16,16 @@ export default function Router($container) {
   const route = (info) => {
     // 현재 페이지에서 Unmount 함수가 있다면 호출합니다.
     if (currentPage !== undefined && currentPage.unmount) currentPage.unmount();
-    // ToDO: 헤더 이동 시 unmount? 비스무리한거 실행해야함
 
     const TargetPage = findMatchedRoute()?.page || ErrorPage; // 현재 경로에 따라 렌더링할 컴포넌트를 정의합니다.
     const TargetHeader = findMatchedRoute()?.header || MainHeader; // 헤더 컴포넌트도 정의합니다.
     if (info != null && info.errorCode) {
       // 에러 페이지로 이동할 때는 errorCode를 전달합니다.
       currentPage = new ErrorPage($container, info.errorCode);
-      currentHeader = new registerHeader($header);
+      currentHeader = new emptyHeader($header);
     } else if (TargetPage === ErrorPage) {
       currentPage = new ErrorPage($container, 401); // 그냥 아래 부분과 합쳐도 되지만 가독성을 위해 분리했습니다.
-      if (currentHeader instanceof MainHeader) return; // 이전 페이지와 같은 페이지로 이동할 때는 렌더링하지 않습니다.
-      currentHeader = new MainHeader($header);
+      currentHeader = new emptyHeader($header);
     } else {
       if (currentPage instanceof TargetPage) return; // 이전 페이지와 같은 페이지로 이동할 때는 렌더링하지 않습니다.
       currentPage = new TargetPage($container, info);


### PR DESCRIPTION
**************************************************************************************
## ✅ 풀\_리퀘스트 체크리스트
<!--
하나씩 확인 후 체크박스에 표시해주세요.
-->
- [v] PR 제목: [feat/fix/refactor...] 작업 내용 한 줄 요약 (브랜치 이름) #이슈번호
- [v] commit message 가 적절한지 확인해주세요.
- [v] 적절한 branch 로 요청했는지 확인해주세요.
- [v] Assignees, Label 을 붙여주세요.
- [v] 주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 Reviewer 로 등록해주세요.
- [v] PR이 승인된 경우 해당 브랜치는 삭제해 주세요!

## 🔄 변경 사항
<!-- 해당 pr에서 작업한 내역을 적어주세요. 처음엔 간단하게 요약, list 형식으로 세부사항 작성 -->
무엇을 합니다!
- errorPage에 중복로그인 관련 컬럼 추가
- errorPage에 emptyHeader로 변경\
- game-mode, waiting-room에서 소켓 연결해서 tournament페이지로 넘겨줌
- tournament 페이지에서 소켓 받아서 변수로 달아줌 (이제 onmessage달아서 render함수 연결하시면 됩니다)

<!-- 관련되어있는 Issue Number 를 작성하세요! 해당 이슈를 이곳에 적으면 pr merge 이후 해당 이슈는 자동으로 close 됩니다. -->
closes: #356
**************************************************************************************
